### PR TITLE
Improve SEO metadata

### DIFF
--- a/app/impressum/head.tsx
+++ b/app/impressum/head.tsx
@@ -6,6 +6,13 @@ export default function Head() {
         name="description"
         content="Impressum und Datenschutzerklärung von Mathis Kräkel."
       />
+      <link rel="canonical" href="https://mathiskraekel.de/impressum" />
+      <meta property="og:title" content="Impressum & Datenschutz | Mathis Kräkel" />
+      <meta property="og:description" content="Impressum und Datenschutzerklärung von Mathis Kräkel." />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://mathiskraekel.de/impressum" />
+      <meta property="og:site_name" content="Mathis Kräkel – Softwareentwicklung & Beratung" />
+      <meta name="robots" content="index, follow" />
     </>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,8 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://mathiskraekel.de"),
+  alternates: { canonical: "/" },
   title: "Mathis Kräkel - Softwareentwicklung & Beratung",
   description: "Professionelle Softwareentwicklung und technische Beratung für moderne Web-Anwendungen. Maßgeschneiderte Lösungen mit React, Next.js, Node.js und TypeScript – individuell entwickelt für Ihre digitalen Herausforderungen.",
   keywords: [

--- a/app/lead-generation/head.tsx
+++ b/app/lead-generation/head.tsx
@@ -6,6 +6,13 @@ export default function Head() {
         name="description"
         content="Maßgeschneiderte Formulare mit Echtzeit-Berechnungen und automatischer Lead-Qualifizierung."
       />
+      <link rel="canonical" href="https://mathiskraekel.de/lead-generation" />
+      <meta property="og:title" content="Intelligente Lead-Formulare | Mathis Kräkel" />
+      <meta property="og:description" content="Maßgeschneiderte Formulare mit Echtzeit-Berechnungen und automatischer Lead-Qualifizierung." />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://mathiskraekel.de/lead-generation" />
+      <meta property="og:site_name" content="Mathis Kräkel – Softwareentwicklung & Beratung" />
+      <meta name="robots" content="index, follow" />
     </>
   );
 }

--- a/app/mvp-development/head.tsx
+++ b/app/mvp-development/head.tsx
@@ -6,6 +6,13 @@ export default function Head() {
         name="description"
         content="Schnelle Entwicklung Ihres Minimum Viable Products mit modernem Tech-Stack. Von der Idee bis zum Launch in 4-8 Wochen."
       />
+      <link rel="canonical" href="https://mathiskraekel.de/mvp-development" />
+      <meta property="og:title" content="MVP Development in Rekordzeit | Mathis Kräkel" />
+      <meta property="og:description" content="Schnelle Entwicklung Ihres Minimum Viable Products mit modernem Tech-Stack. Von der Idee bis zum Launch in 4-8 Wochen." />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://mathiskraekel.de/mvp-development" />
+      <meta property="og:site_name" content="Mathis Kräkel – Softwareentwicklung & Beratung" />
+      <meta name="robots" content="index, follow" />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- enhance site metadata configuration
- add canonical and open graph meta tags for the lead generation, MVP development, and impressum pages

## Testing
- `npm run format` *(fails: bunx not found)*
- `npm run lint` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ebed42a48331831e3d3de5d90790