### PR TITLE
Add VKB Zahn100 project

### DIFF
--- a/app/lead-generation/page.tsx
+++ b/app/lead-generation/page.tsx
@@ -372,10 +372,26 @@ export default function LeadGenerationPage() {
                   </CardHeader>
                   <CardContent>
                     <p className="text-slate-300 mb-4">
-                      Produkt-Konfigurator mit Live-Preisberechnung. 
+                      Produkt-Konfigurator mit Live-Preisberechnung.
                       Konfiguration wird gespeichert und kann per E-Mail angefordert werden.
                     </p>
                     <div className="text-sm text-green-400">→ Kaufinteressenten sammeln</div>
+                  </CardContent>
+                </Card>
+              </motion.div>
+
+              <motion.div variants={fadeInUp}>
+                <Card className="bg-gradient-to-br from-slate-800/50 to-slate-900/50 border-slate-700/50 backdrop-blur-sm h-full">
+                  <CardHeader>
+                    <div className="text-red-400 font-semibold mb-2">Für Versicherungen</div>
+                    <CardTitle>VKB Zahn100 Funnel</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-slate-300 mb-4">
+                      Online-Rechner und Abschlussstrecke für den Tarif Zahn100 der Versicherungskammer Bayern.
+                      Interessenten erhalten ihr Angebot in wenigen Schritten.
+                    </p>
+                    <div className="text-sm text-green-400">→ Digitale Abschlussstrecke</div>
                   </CardContent>
                 </Card>
               </motion.div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,6 +119,13 @@ export default function Home() {
       // githubUrl: "https://github.com/mkraekel/portfolio-cms",
       featured: true
     },
+    {
+      title: "VKB Zahn100 – Lead-Funnel für Zahnzusatzversicherung",
+      description: "Interaktiver Online-Rechner für den Tarif Zahn100 der Versicherungskammer Bayern. Besucher erhalten nach wenigen Eingaben ein individuelles Angebot und können den Antrag direkt starten.",
+      technologies: ["Next.js", "React", "TailwindCSS"],
+      liveUrl: "https://vkb-zahn100.de/?step=0",
+      featured: true
+    },
   ]
 
   return (


### PR DESCRIPTION
## Summary
- add VKB Zahn100 project to projects list on start page
- add VKB Zahn100 example on lead generation page
- remove broken placeholder image

## Testing
- `npm run lint` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bffab4a988331911ad494c9d9423d